### PR TITLE
refactor: use English-only comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Litematica Shulker Supply
 
-> 中文版 **[README.zh.md](README.zh.md)**
+> Chinese version: **[README.zh.md](README.zh.md)**
 
 A tiny Fabric mod that teaches **Litematica** (and optionally **Litematica Printer**) to auto‑restock from **Shulker Boxes** in your **player inventory**. When an item is missing, it is automatically taken from the Shulker Box and placed in the hotbar.
 

--- a/src/main/java/top/lqsnow/lss/LitematicaShulkerSupply.java
+++ b/src/main/java/top/lqsnow/lss/LitematicaShulkerSupply.java
@@ -24,8 +24,6 @@ import top.lqsnow.lss.net.SwapFromShulkerC2S;
 /**
  * Server entry point of the mod. Registers networking payloads, handles
  * shulker-to-hotbar swapping and loads the configuration on startup.
- * <p>
- * 模组服务端入口，负责注册网络负载、处理潜影盒与快捷栏的互换逻辑，并在启动时加载配置。
  */
 public class LitematicaShulkerSupply implements ModInitializer {
     public static final String MOD_ID = "litematica-shulker-supply";
@@ -34,7 +32,6 @@ public class LitematicaShulkerSupply implements ModInitializer {
 
     /**
      * Initialize networking payloads and read configuration.
-     * 初始化：注册网络负载与处理器，并读取配置。
      */
     @Override
     public void onInitialize() {
@@ -66,12 +63,10 @@ public class LitematicaShulkerSupply implements ModInitializer {
      * Execute the swap: move one slot from shulker box to a hotbar slot and put
      * the previous hotbar item back into the shulker. Any invalid parameter will
      * simply abort the operation silently.
-     * <p>
-     * 交换执行：潜影盒内某格与玩家快捷栏某槽整格互换。如参数非法则直接返回。
      */
     private static void handleSwapFromShulker(ServerPlayerEntity player, int boxContainerSlotId, int innerIndex, int destHotbar) {
         if (destHotbar < 0 || destHotbar > 8) return;
-        if (player.isCreative()) return; // 可选：与客户端保持一致
+        if (player.isCreative()) return; // Optional: match client behavior
 
         PlayerScreenHandler handler = player.playerScreenHandler;
         if (boxContainerSlotId < 0 || boxContainerSlotId >= handler.slots.size()) return;

--- a/src/main/java/top/lqsnow/lss/client/LitematicaShulkerSupplyClient.java
+++ b/src/main/java/top/lqsnow/lss/client/LitematicaShulkerSupplyClient.java
@@ -14,10 +14,8 @@ import top.lqsnow.lss.net.HandshakeS2C;
 import top.lqsnow.lss.net.SwapFromShulkerC2S;
 
 /**
- * Client entry point. Performs handshake with the server and records whether
- * the server has this mod installed.
- * <p>
- * 客户端入口，负责与服务器进行握手，并记录服务器是否安装了本模组。
+ * Client entry point. Performs a handshake with the server and records
+ * whether the server has this mod installed.
  */
 @Environment(EnvType.CLIENT)
 public class LitematicaShulkerSupplyClient implements ClientModInitializer {
@@ -26,11 +24,12 @@ public class LitematicaShulkerSupplyClient implements ClientModInitializer {
             FabricLoader.getInstance().getConfigDir().resolve(LitematicaShulkerSupply.MOD_ID + ".json")
     );
 
-    /** 标记当前服务器是否已加载本模组 */
+    /** Flag indicating whether the current server has the mod installed */
     public static volatile boolean SERVER_HAS_MOD = false;
 
     /**
-     * 初始化客户端：注册握手逻辑，在进入世界时进行检测。
+     * Initialize the client by registering handshake logic and performing
+     * checks when joining a world.
      */
     @Override
     public void onInitializeClient() {
@@ -40,7 +39,7 @@ public class LitematicaShulkerSupplyClient implements ClientModInitializer {
             LitematicaShulkerSupply.LOGGER.warn("[{}] Failed to pre-load config: {}", LitematicaShulkerSupply.MOD_ID, e.getMessage());
         }
 
-        // 进服事件：安全握手
+        // On join: perform handshake
         ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {
             SERVER_HAS_MOD = false;
             if (ClientPlayNetworking.canSend(HandshakeC2S.ID)) {
@@ -48,12 +47,12 @@ public class LitematicaShulkerSupplyClient implements ClientModInitializer {
             }
         });
 
-        // 断线时重置
+        // Reset on disconnect
         ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> {
             SERVER_HAS_MOD = false;
         });
 
-        // 收到握手回应
+        // Receive handshake response
         ClientPlayNetworking.registerGlobalReceiver(HandshakeS2C.ID, (payload, context) -> {
             SERVER_HAS_MOD = payload.ok();
         });

--- a/src/main/java/top/lqsnow/lss/config/ConfigManager.java
+++ b/src/main/java/top/lqsnow/lss/config/ConfigManager.java
@@ -16,15 +16,13 @@ import java.nio.file.Path;
  * Manages loading and saving the mod's configuration. Values from
  * {@link Configs} (malilib's {@code ConfigBoolean}) are mapped to a simple
  * JSON file.
- * <p>
- * 负责把 Configs 里的值（malilib 的 ConfigBoolean）映射到我们自己的 JSON 文件。
  */
 public final class ConfigManager {
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private final Path file;
 
     /**
-     * @param file 配置文件路径
+     * @param file path to the configuration file
      */
     public ConfigManager(Path file) {
         this.file = file;
@@ -33,12 +31,10 @@ public final class ConfigManager {
     /**
      * Load configuration from disk into memory. Writes default configuration if
      * the file does not exist.
-     * <p>
-     * 从磁盘读取配置到内存。若文件不存在则写入默认配置。
      */
     public void load() throws IOException {
         if (!Files.exists(file)) {
-            // 首次运行：按默认值写一个文件
+            // First run: write a file with default values
             save();
             return;
         }
@@ -56,8 +52,6 @@ public final class ConfigManager {
 
     /**
      * Save in-memory configuration back to disk.
-     * <p>
-     * 将内存中的配置写回磁盘。
      */
     public void save() {
         try {

--- a/src/main/java/top/lqsnow/lss/config/Configs.java
+++ b/src/main/java/top/lqsnow/lss/config/Configs.java
@@ -10,8 +10,6 @@ import java.util.List;
 
 /**
  * Collection of configuration options for the mod.
- * <p>
- * mod 自身的配置项集合。
  */
 public final class Configs {
     private Configs() {
@@ -26,8 +24,6 @@ public final class Configs {
     /**
      * Return the list of custom configuration options for registration with
      * Litematica.
-     * <p>
-     * 返回本模组自定义的配置项列表，供 Litematica 注册。
      */
     public static ImmutableList<IConfigBase> getOwnOptions() {
         List<IConfigBase> list = new ArrayList<>();

--- a/src/main/java/top/lqsnow/lss/mixin/AccessorLitematicaInventoryUtils.java
+++ b/src/main/java/top/lqsnow/lss/mixin/AccessorLitematicaInventoryUtils.java
@@ -7,24 +7,25 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
 /**
- * 通过 Invoker 暴露 Litematica 自带的 InventoryUtils 的私有方法，供本模组复用。
+ * Exposes private methods of Litematica's InventoryUtils via Invokers for reuse
+ * in this mod.
  */
 @Mixin(value = fi.dy.masa.litematica.util.InventoryUtils.class)
 public interface AccessorLitematicaInventoryUtils {
 
-    /** 调用 InventoryUtils#getEmptyPickBlockableHotbarSlot */
+    /** Invoke InventoryUtils#getEmptyPickBlockableHotbarSlot */
     @Invoker("getEmptyPickBlockableHotbarSlot")
     static int lss$invokeGetEmptyPickBlockableHotbarSlot(PlayerInventory inventory) {
         throw new AssertionError();
     }
 
-    /** 调用 InventoryUtils#getPickBlockTargetSlot */
+    /** Invoke InventoryUtils#getPickBlockTargetSlot */
     @Invoker("getPickBlockTargetSlot")
     static int lss$invokeGetPickBlockTargetSlot(PlayerEntity player) {
         throw new AssertionError();
     }
 
-    /** 调用 InventoryUtils#canPickToSlot */
+    /** Invoke InventoryUtils#canPickToSlot */
     @Invoker("canPickToSlot")
     static boolean lss$invokeCanPickToSlot(PlayerInventory inventory, int slotNum) {
         throw new AssertionError();

--- a/src/main/java/top/lqsnow/lss/mixin/ConfigsGenericMixin.java
+++ b/src/main/java/top/lqsnow/lss/mixin/ConfigsGenericMixin.java
@@ -12,18 +12,19 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import top.lqsnow.lss.config.Configs;
 
 /**
- * 向 Litematica 原生的 Generic 配置选项列表追加本模组自定义的选项。
+ * Adds this mod's custom options to Litematica's native Generic configuration
+ * list.
  */
 @Mixin(value = fi.dy.masa.litematica.config.Configs.Generic.class, remap = false, priority = 900)
 public abstract class ConfigsGenericMixin {
     @Shadow @Mutable public static ImmutableList<IConfigBase> OPTIONS;
 
-    // 在 Generic 的 <clinit>（静态初始化）后，把我们的选项追加到 OPTIONS
+    // After Generic's <clinit> (static initialization), append our options to OPTIONS
     @Inject(method = "<clinit>", at = @At("TAIL"))
     private static void lss$appendOwnOptions(CallbackInfo ci) {
         OPTIONS = new ImmutableList.Builder<IConfigBase>()
                 .addAll(OPTIONS)
-                .addAll(Configs.getOwnOptions()) // ← 只返回我们自己的条目（不要把原生再装进来）
+                .addAll(Configs.getOwnOptions()) // ← returns only our entries (do not re-add originals)
                 .build();
     }
 }

--- a/src/main/java/top/lqsnow/lss/mixin/ConfigsMixin.java
+++ b/src/main/java/top/lqsnow/lss/mixin/ConfigsMixin.java
@@ -9,7 +9,8 @@ import top.lqsnow.lss.LitematicaShulkerSupply;
 import top.lqsnow.lss.client.LitematicaShulkerSupplyClient;
 
 /**
- * 在 Litematica 读取和保存配置时同步本模组的配置文件。
+ * Synchronizes this mod's config file when Litematica loads or saves its own
+ * configuration.
  */
 @Mixin(value = Configs.class, remap = false, priority = 500)
 public class ConfigsMixin {
@@ -19,7 +20,7 @@ public class ConfigsMixin {
         try {
             LitematicaShulkerSupplyClient.CONFIG.load();
         } catch (Exception e) {
-            // 已在管理器里做了日志，这里不再重复抛异常
+            // Logging handled in the manager; suppress exception
         }
     }
 

--- a/src/main/java/top/lqsnow/lss/mixin/MixinLitematicaInventoryUtils.java
+++ b/src/main/java/top/lqsnow/lss/mixin/MixinLitematicaInventoryUtils.java
@@ -40,13 +40,13 @@ public abstract class MixinLitematicaInventoryUtils {
         var player = mc.player;
         if (player == null) return false;
 
-        // 主背包（含热栏）
+        // Main inventory including hotbar
         for (ItemStack s : player.getInventory().getMainStacks()) {
             if (!s.isEmpty() && fi.dy.masa.malilib.util.InventoryUtils.areStacksEqualIgnoreNbt(s, required)) {
                 return true;
             }
         }
-        // 副手
+        // Offhand
         ItemStack off = player.getOffHandStack();
         return !off.isEmpty() && fi.dy.masa.malilib.util.InventoryUtils.areStacksEqualIgnoreNbt(off, required);
     }

--- a/src/main/java/top/lqsnow/lss/mixin/PrinterMixinPlugin.java
+++ b/src/main/java/top/lqsnow/lss/mixin/PrinterMixinPlugin.java
@@ -13,7 +13,7 @@ public final class PrinterMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public void onLoad(String mixinPackage) {
-        // 两种可能的 modid 都试一下；再兜底用类存在性判断
+        // Try both potential mod IDs; fallback to checking class existence
         this.hasPrinter =
                 FabricLoader.getInstance().isModLoaded("litematica-printer")
                         || FabricLoader.getInstance().isModLoaded("litematica_printer")
@@ -31,12 +31,12 @@ public final class PrinterMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public String getRefMapperConfig() {
-        return null; // 用默认 refmap
+        return null; // use default refmap
     }
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        // 仅当装了 Printer 时，才启用对其的适配 mixin
+        // Enable printer-specific mixins only if the printer mod is present
         if (mixinClassName.endsWith("printer.GuideShulkerAccessMixin")
                 || mixinClassName.endsWith("printer.PrepareActionSupplyMixin")) {
             return hasPrinter;
@@ -48,7 +48,7 @@ public final class PrinterMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public List<String> getMixins() {
-        // 返回 null 让 Mixin 使用 json 里的列表
+        // Return null to let Mixin use the list from the JSON
         return null;
     }
 

--- a/src/main/java/top/lqsnow/lss/mixin/printer/PrepareActionSupplyMixin.java
+++ b/src/main/java/top/lqsnow/lss/mixin/printer/PrepareActionSupplyMixin.java
@@ -19,14 +19,15 @@ import fi.dy.masa.litematica.config.Configs;
 import fi.dy.masa.litematica.util.EntityUtils;
 
 /**
- * 在打印机执行准备动作时，提前尝试从潜影盒中补充所需物品。
+ * During the printer's prepare action, attempt to supply required items from
+ * shulker boxes ahead of time.
  */
 @Mixin(value = PrepareAction.class)
 public abstract class PrepareActionSupplyMixin {
 
     @Final
     @Shadow
-    public PrinterPlacementContext context; // ✅ 正确 Shadow 目标字段
+    public PrinterPlacementContext context; // Shadowed target field
 
     @Inject(method = "send(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/network/ClientPlayerEntity;)V",
             at = @At("HEAD"))

--- a/src/main/java/top/lqsnow/lss/net/HandshakeC2S.java
+++ b/src/main/java/top/lqsnow/lss/net/HandshakeC2S.java
@@ -10,8 +10,6 @@ import static top.lqsnow.lss.LitematicaShulkerSupply.MOD_ID;
 /**
  * Handshake packet sent from client to server to check whether the server has
  * this mod installed.
- * <p>
- * 客户端向服务端发送的握手数据包，用于检测对方是否安装本模组。
  */
 public record HandshakeC2S() implements CustomPayload {
     public static final Id<HandshakeC2S> ID = new Id<>(Identifier.of(MOD_ID, "hello_c2s"));

--- a/src/main/java/top/lqsnow/lss/net/HandshakeS2C.java
+++ b/src/main/java/top/lqsnow/lss/net/HandshakeS2C.java
@@ -10,8 +10,6 @@ import static top.lqsnow.lss.LitematicaShulkerSupply.MOD_ID;
 /**
  * Handshake response sent from server to client indicating whether the server
  * has the mod installed.
- * <p>
- * 服务端回应客户端的握手数据包，告知是否安装了本模组。
  */
 public record HandshakeS2C(boolean ok) implements CustomPayload {
     public static final Id<HandshakeS2C> ID = new Id<>(Identifier.of(MOD_ID, "hello_s2c"));

--- a/src/main/java/top/lqsnow/lss/net/SwapFromShulkerC2S.java
+++ b/src/main/java/top/lqsnow/lss/net/SwapFromShulkerC2S.java
@@ -10,8 +10,6 @@ import static top.lqsnow.lss.LitematicaShulkerSupply.MOD_ID;
 /**
  * Client packet notifying the server to swap a slot in a shulker box with a
  * hotbar slot.
- * <p>
- * 客户端通知服务端：将潜影盒中的某格与玩家快捷栏槽位进行整格互换。
  */
 public record SwapFromShulkerC2S(int boxContainerSlotId, int innerIndex, int destHotbarSlot) implements CustomPayload {
 

--- a/src/main/java/top/lqsnow/lss/printer/ShulkerScan.java
+++ b/src/main/java/top/lqsnow/lss/printer/ShulkerScan.java
@@ -14,8 +14,6 @@ import java.util.List;
 
 /**
  * Utility helpers for scanning shulker boxes when used with printers.
- * <p>
- * 与打印机相关的潜影盒扫描工具。
  */
 public final class ShulkerScan {
     private ShulkerScan() {}
@@ -24,9 +22,6 @@ public final class ShulkerScan {
      * Search the player's visible container for the first shulker box containing
      * any of the candidate items. Returns a copy of the matching stack or
      * {@code null} if not found.
-     * <p>
-     * 在玩家可见容器（自身背包面板）里，查找第一只包含 candidates 中任一物品的潜影盒；
-     * 找到则返回盒内真实的 ItemStack 副本；找不到返回 null。
      */
     public static ItemStack findFirstInAnyShulker(ClientPlayerEntity player, List<ItemStack> candidates) {
         if (player == null || candidates == null || candidates.isEmpty()) return null;


### PR DESCRIPTION
## Summary
- replace bilingual comments with English-only comments across the codebase
- clarify README header link to Chinese documentation

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68ad2cfe10848325b9b76aa1fcb20422